### PR TITLE
Add-google-signin-authentication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ gem 'carrierwave'
 gem 'mini_magick'
 gem 'omniauth'
 gem 'omniauth-facebook'
+gem 'omniauth-google-oauth2'
 gem 'jquery-rails'
 gem 'payjp'
 gem 'aws-sdk-s3',require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,10 @@ GEM
       rack (>= 1.6.2, < 3)
     omniauth-facebook (5.0.0)
       omniauth-oauth2 (~> 1.2)
+    omniauth-google-oauth2 (0.6.1)
+      jwt (>= 2.0)
+      omniauth (>= 1.1.1)
+      omniauth-oauth2 (>= 1.5)
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
@@ -387,6 +391,7 @@ DEPENDENCIES
   mysql2 (>= 0.4.4, < 0.6.0)
   omniauth
   omniauth-facebook
+  omniauth-google-oauth2
   payjp
   pry-rails
   puma (~> 3.11)

--- a/app/assets/stylesheets/modules/_users-new.scss
+++ b/app/assets/stylesheets/modules/_users-new.scss
@@ -1,5 +1,3 @@
-.new_user_header{
-}
 .register-btn{
   &__mail{
     margin: auto;
@@ -45,6 +43,7 @@
     }
   }
   &__google{
+    color:$font_black;
     margin: auto;
     background-color: white;
     border: 1px black solid;

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,5 +1,5 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  def facebook
+  def callback_for_all_providers
     # You need to implement the method below in your model (e.g. app/models/user.rb)
     info = User.from_omniauth(request.env["omniauth.auth"]) #リクエストを送ってきたユーザのヘッダー情報や環境変数を取得する
     @user = info[:user]
@@ -7,12 +7,15 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     if  @user.persisted? #保存済みかどうかチェック
       sign_in_and_redirect @user #this will throw if @user is not activated
       # set_flash_message(:notice, :success, kind: "Facebook") if is_navigational_format?
-      flash[:notice] = "Facebookアカウントからログインしました"
+      flash[:notice] = "外部アカウントからログインしました"
     else
       session["devise.sns_id"] = sns_id
       render template: "devise/registrations/new"
     end
   end
+
+  alias_method :facebook, :callback_for_all_providers
+  alias_method :google_oauth2, :callback_for_all_providers
 
   def failure
     redirect_to new_user_registration_path, alert: 'Facebookにアカウントが存在しません。'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,7 +32,7 @@ class User < ApplicationRecord
             provider: provider,
             user_id: user.id
           )
-        else #メルカリに登録していない
+        else #メルカリに登録していない,facebook認証がまだの場合
           user = User.new(
             nickname: auth.info.name,
             email: auth.info.email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,10 +13,10 @@ class User < ApplicationRecord
   def self.from_omniauth(auth)
     uid = auth.uid
     provider = auth.provider
-    snscredential = SnsCredential.where(uid: uid, provider: provider).first 
+    snscredential = SnsCredential.find_by(uid: uid, provider: provider) 
     #すでにデータベースに該当のuid,providerが存在している facebook認証をしている
     if snscredential.present? #facebook認証済みで、該当uid＆providerが存在するとき
-      user = User.where(id: snscredential.user_id).first
+      user = User.find_by(id: snscredential.user_id)
         unless user.present? #紐づくユーザーがいない限りにおいて以下を追加して
           user = User.new(   #そんなことは起こらないけど
             nickname: auth.info.name,
@@ -25,7 +25,7 @@ class User < ApplicationRecord
           end 
       sns = snscredential 
     else #facebook認証がまだの場合。
-      user = User.where(email: auth.info.email).first 
+      user = User.find_by(email: auth.info.email) 
         if user.present? #メルカリに登録済みだけど,facebook認証がまだ。
           sns = SnsCredential.new(
             uid: uid,

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,33 +1,18 @@
--# facebook承認のための記述です。もしかしたら使わないかもしれませんが、今後、使う可能性があるので、残しておきます。
--# :javascript
--#     window.fbAsyncInit = function() {
--#       FB.init({
--#         appId      : '{your-app-id}',
--#         cookie     : true,
--#         xfbml      : true,
--#         version    : '{api-version}'
--#       });
--#       FB.AppEvents.logPageView();
--#     };
--#     (function(d, s, id){
--#       var js, fjs = d.getElementsByTagName(s)[0];
--#       if (d.getElementById(id)) {return;}
--#       js = d.createElement(s); js.id = id;
--#       js.src = "https://connect.facebook.net/en_US/sdk.js";
--#       fjs.parentNode.insertBefore(js, fjs);
--#     }(document, 'script', 'facebook-jssdk'));
 .background
   =render 'shared/products-new-header'
   .inputs
     .new_user_header-signin アカウントをお持ちでない方はこちら
-    =link_to '新規会員登録', new_user_path,class: 'register-new-btn'
+    = link_to '新規会員登録', new_user_path,class: 'register-new-btn'
   .inputs.register-btn
-    =link_to user_facebook_omniauth_authorize_path do
-      .register-btn__facebook
-        .register-btn__facebook__logo
-          =fa_icon("facebook-square")
-        .register-btn__facebook__text Facebookでログイン
-        .register-btn__empty
+    -# = link_to user_facebook_omniauth_authorize_path do 
+    -# initalizer/devise.rbで設定した環境変数に値を入れたのち、↑コメントアウトを外して↓5行をdoの中に入れ
+    .register-btn__facebook
+      .register-btn__facebook__logo
+        =fa_icon("facebook-square")
+      .register-btn__facebook__text Facebookでログイン
+      .register-btn__empty
+    -# = link_to user_google_oauth2_omniauth_authorize_path do
+    -# initalizer/devise.rbで設定した環境変数に値を入れたのち、↑コメントアウトを外して↓5行をdoの中に入れ
     .register-btn__google
       .register-btn__google__logo
         =fa_icon("google")
@@ -47,3 +32,4 @@
         = f.submit "ログイン",class: "login-btn-session"
     = link_to "パスワードをお忘れの方", new_password_path(resource_name), class: 'forget-password'
   =render 'shared/products-new-footer'
+

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -14,9 +14,10 @@
           =fa_icon("facebook-square")
         .register-btn__facebook__text Facebookで登録
         .register-btn__empty
-    .register-btn__google
-      .register-btn__google__logo
-        =fa_icon("google")
-      .register-btn__google__text Googleで登録
-      .register-btn__empty
+    = link_to user_google_oauth2_omniauth_authorize_path do
+      .register-btn__google
+        .register-btn__google__logo
+          =fa_icon("google")
+        .register-btn__google__text Googleで登録
+        .register-btn__empty
   =render 'shared/products-new-footer'

--- a/app/views/users/new.html.haml
+++ b/app/views/users/new.html.haml
@@ -8,16 +8,18 @@
         =fa_icon("envelope")
       .register-btn__mail__text メールアドレスで登録
       .register-btn__empty
-    =link_to user_facebook_omniauth_authorize_path do
-      .register-btn__facebook
-        .register-btn__facebook__logo
-          =fa_icon("facebook-square")
-        .register-btn__facebook__text Facebookで登録
-        .register-btn__empty
-    = link_to user_google_oauth2_omniauth_authorize_path do
-      .register-btn__google
-        .register-btn__google__logo
-          =fa_icon("google")
-        .register-btn__google__text Googleで登録
-        .register-btn__empty
+    -# =link_to user_facebook_omniauth_authorize_path do
+    -# initalizer/devise.rbで設定した環境変数に値を入れたのち、↑コメントアウトを外して↓5行をdoの中に入れ
+    .register-btn__facebook
+      .register-btn__facebook__logo
+        =fa_icon("facebook-square")
+      .register-btn__facebook__text Facebookで登録
+      .register-btn__empty
+    -# = link_to user_google_oauth2_omniauth_authorize_path do
+    -# initalizer/devise.rbで設定した環境変数に値を入れたのち、↑コメントアウトを外して↓5行をdoの中に入れ
+    .register-btn__google
+      .register-btn__google__logo
+        =fa_icon("google")
+      .register-btn__google__text Googleで登録
+      .register-btn__empty
   =render 'shared/products-new-footer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -65,6 +65,7 @@ Devise.setup do |config|
   # enable it only for database (email + password) authentication.
   # config.params_authenticatable = true
   config.omniauth :facebook, ENV['FACEBOOK_APP_ID'], ENV['FACEBOOK_APP_SECRET']
+  config.omniauth :google_oauth2, ENV['GOOGLE_CLIENT_ID'], ENV['GOOGLE_ClIENT_SECRET']
   # Tell if authentication through HTTP Auth is enabled. False by default.
   # It can be set to an array that will enable http authentication only for the
   # given strategies, for example, `config.http_authenticatable = [:database]` will


### PR DESCRIPTION
## WHAT 
### グーグルSNS認証
## WHY
### アカウント登録の間口を広げるため。
## ATTENTION
### ドメインを本番環境に持っていないのでローカルでしか作動しません。
### なのでviewの部分をコメントアウトしております。
### SNS認証をローカルで試したい場合は
### ①credential.enc.ymlか
### ②自分のパソコンの中の~/.bash_profileか
### ③gem dotenvを使用して.envファイルにか
### 上記①~③のいずれかに,
### initialzer/devise.rbのconfig.omniauth以下に記述のある環境変数を設定してからお試し下さい。
